### PR TITLE
fix(index.js): fix path resolving for prefixed urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function koaBetterServe (dir, pathname, opts) {
     return pathname.test(ctx.url)
       ? next().then(function () {
         var fp = ctx.path.replace(pathname, '')
-        var fpath = path.relative(dir, path.resolve(dir, fp))
+        var fpath = path.relative(dir, path.join(dir, fp))
         return send(ctx, fpath, opts)
       })
       : next()

--- a/test.js
+++ b/test.js
@@ -83,3 +83,13 @@ test('should serve `koa-send`s package.json when `/package.json` request', funct
     .expect(/koa-send/)
     .expect(200, done)
 })
+
+test('should serve `koa-send`s package.json when `/package.json` request with prefix', function (done) {
+  var app = new Koa()
+  app.use(serve('./node_modules/koa-send', '/koa-send'))
+
+  request(app.callback())
+    .get('/koa-send/package.json')
+    .expect(/koa-send/)
+    .expect(200, done)
+})


### PR DESCRIPTION
There was an incorrect path resolution in case of mapping of a serving directory to a prefixed url.

The reason is the `path.resolve()` function doesn't join its arguments. And in case of prefixed url, the `fp` parameter contains a leading slash.